### PR TITLE
Add tagcloud for tags layout and show tag in index article block( right to category)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ menu:
   Home: /
   Archives: /archives
   # Category: /category
-  Tags: /tags/
+  # Tags: /tags/
   # Links: /links
   # About: /about
   # ...
@@ -106,3 +106,9 @@ magic:
   sidebar:
     enable: false
     position: right  # values: left | right
+
+# Home page article block display settings
+home_article:
+  tag: true # show tags in article block
+  tag_limit: 5 # max number of tags shown in article block
+  category: true # show category in article block

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ menu:
   Home: /
   Archives: /archives
   # Category: /category
+  Tags: /tags/
   # Links: /links
   # About: /about
   # ...

--- a/layout/_partial/tagcloud.ejs
+++ b/layout/_partial/tagcloud.ejs
@@ -1,0 +1,9 @@
+<% if (site.tags.length){ %>
+    <div class="fade-in-down-animation">
+        <div class="tagcloud-container">
+            <div class = "tagcloud-content">
+                <%- tagcloud({min_font:15,max_font:25}) %>
+            </div>
+        </div>
+    </div>
+<% } %>

--- a/layout/home-content.ejs
+++ b/layout/home-content.ejs
@@ -24,6 +24,7 @@
                     <div class="article-date">
                         <span><i class="fa fa-pencil-square-o"></i> <%= date(post.date, 'YYYY-MM-DD') %></span>
                         <% if (theme.magic.enable === true) { %>
+                            <% if (theme.home_article.category === true) { %>
                             <span>
                             <i class="fa fa-folder"></i>
                             <ul>
@@ -32,7 +33,20 @@
                                                 href="<%- url_for(category.path) %>"><%= category.name %></a></li>
                                 <% }); %>
                             </ul>
-                        </span>
+                            </span>
+                            <% } %>
+                            <% if (theme.home_article.tag === true) { %>
+                            <span>
+                            <i class="fa fa-tags"></i>
+                            <ul>
+                                <% post.tags.forEach((tag, i) => { 
+                                    if (theme.home_article.tag_limit===0 | i+1<= theme.home_article.tag_limit) {%>
+                                        <li><%= i === 0 ? '' : '| ' %><a
+                                                    href="<%- url_for(tag.path) %>"><%= tag.name %></a></li>
+                                <% }}); %>
+                            </ul>
+                            </span>
+                            <% } %>
                         <% } %>
                     </div>
                     <% if (theme.magic.enable === false) { %>

--- a/layout/page.ejs
+++ b/layout/page.ejs
@@ -31,6 +31,9 @@
 
                 <% } else if (page.title == 'links') { %>
                     <%- partial('links') %>
+                    
+                <% } else if (page.title == 'tags') { %>
+                    <%- partial('_partial/tagcloud') %>
                 <% } %>
 
             </div>

--- a/layout/tags.ejs
+++ b/layout/tags.ejs
@@ -1,0 +1,1 @@
+<%- partial('page') %>

--- a/source/css/layout/_partial/tagcloud.styl
+++ b/source/css/layout/_partial/tagcloud.styl
@@ -1,0 +1,18 @@
+
+@require "../common/magic-theme.styl";
+
+.tagcloud-container {
+
+    background: var(--background-color);
+
+    magic-container(1.005,1.01,30px);
+    
+    .tagcloud-content{
+        a{
+            margin-right: 5px;
+            display: inline-block;
+        }
+
+    }
+
+}

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -28,3 +28,4 @@
 @import "layout/_partial/sidebar-categories.styl"
 @import "layout/_partial/sidebar-tags.styl"
 @import "layout/_partial/sidebar-tagcloud.styl"
+@import "layout/_partial/tagcloud.styl"


### PR DESCRIPTION
Hi,
感谢作者提供的优秀theme，由于我是一个重度tag使用者，但是当前theme没有提供tag页面相关的实现，所以我实现了一个简单的tagcloud标签。
同时我以tag标注文章而非category，我期望index页面的文章block能够显示tag list，所以我添加了config的选项可以选择在category右侧显示tag list。

我不熟悉前端开发，添加的也都是很基础的实现，也感谢作者做更好的优化。
